### PR TITLE
call Reset in the appropriate places instead of Close

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -147,10 +147,10 @@ func (c *Conn) Close() error {
 
 	c.closed = true
 
-	// close streams
+	// reset streams
 	streams := c.Streams()
 	for _, s := range streams {
-		s.Close()
+		s.Reset()
 	}
 
 	// close underlying connection
@@ -302,6 +302,11 @@ func (s *Swarm) setupStream(smuxStream smux.Stream, c *Conn) *Stream {
 	return stream
 }
 
+// TODO: Really, we need to either not track them here or, possibly, add a
+// notification system to go-stream-muxer (shudder).
+// Alternatively, we could garbage collect them like we do connections but then
+// we'd need a way to determine which connections are open (we'd need IsClosed)
+// methods.
 func (s *Swarm) removeStream(stream *Stream) error {
 
 	// remove from our maps
@@ -312,7 +317,9 @@ func (s *Swarm) removeStream(stream *Stream) error {
 	s.streamLock.Unlock()
 	stream.conn.streamLock.Unlock()
 
-	err := stream.smuxStream.Close()
+	err := stream.smuxStream.Reset()
+	// TODO: Does this even make sense with half-open streams?
+	// TODO: This will fire once per call to Reset (possibly multiple times...)
 	s.notifyAll(func(n Notifiee) {
 		n.ClosedStream(stream)
 	})

--- a/handlers.go
+++ b/handlers.go
@@ -27,10 +27,10 @@ func EchoHandler(s *Stream) {
 	}()
 }
 
-// CloseHandler is a StreamHandler which simply closes
+// ResetHandler is a StreamHandler which simply resets
 // the stream.
-func CloseHandler(s *Stream) {
-	s.Close()
+func ResetHandler(s *Stream) {
+	s.Reset()
 }
 
 // NoOpStreamHandler is a StreamHandler which does nothing.

--- a/stream.go
+++ b/stream.go
@@ -86,14 +86,14 @@ func (s *Stream) Write(p []byte) (n int, err error) {
 	return s.smuxStream.Write(p)
 }
 
-// Reset resets the stream.
+// Reset resets the stream and removes it from the swarm.
 func (s *Stream) Reset() error {
-	return s.smuxStream.Reset()
+	return s.conn.swarm.removeStream(s)
 }
 
-// Close closes the stream and removes it from the swarm.
+// Close closes the write end of the stream.
 func (s *Stream) Close() error {
-	return s.conn.swarm.removeStream(s)
+	return s.smuxStream.Close()
 }
 
 // Protocol returns the protocol identifier associated to this Stream.

--- a/swarm.go
+++ b/swarm.go
@@ -335,7 +335,7 @@ func (s *Swarm) Close() error {
 
 	// automatically close everything new we get.
 	s.SetConnHandler(func(c *Conn) { c.Close() })
-	s.SetStreamHandler(func(s *Stream) { s.Close() })
+	s.SetStreamHandler(func(s *Stream) { s.Reset() })
 
 	var wgl sync.WaitGroup
 	for _, l := range s.Listeners() {


### PR DESCRIPTION
Also:

* Add a bunch of TODOs
* Only remove the stream when it has been reset, not when it is closed (we'll
  have to track remote resets but we can handle that later).